### PR TITLE
Add Release Notes section to README linking to the iOS SDK changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # didomi-ios-sdk-spm
 A Swift Package of the Didomi iOS SDK
+
+## Release Notes
+Release notes for each version are available in the iOS SDK changelog: https://developers.didomi.io/cmp/mobile-sdk/ios/versions


### PR DESCRIPTION
### Description
Adds a short **Release Notes** section to the README pointing to the official iOS SDK changelog, so anyone browsing this Swift Package repo can quickly find per-version release notes. The GitHub Releases tab on this repo is currently empty, so the link improves discoverability.

Changelog: https://developers.didomi.io/cmp/mobile-sdk/ios/versions